### PR TITLE
docs: fix typos in features.md and llvm_tool.md

### DIFF
--- a/bazel/docs/features.md
+++ b/bazel/docs/features.md
@@ -2,7 +2,7 @@
 
 | Feature | Target | Description |
 | ------- | ------ | ----------- |
-| `debug_symbols` | `//feature:debug_symbols` | Generage debug information |
+| `debug_symbols` | `//feature:debug_symbols` | Generate debug information |
 | `hide_symbols` | `//feature:hide_symbols` | Set hidden symbol visibility |
 | `strip_unused_dynamic_libs` | `//feature:strip_unused_dynamic_libs` | Don't link against dynamic libraries that aren't referenced by any symbols |
 | `thinlto` | `//feature:thinlto` | Link with ThinLTO (incremental link time optimization) |

--- a/bazel/docs/llvm_tool.md
+++ b/bazel/docs/llvm_tool.md
@@ -40,7 +40,7 @@ llvm_tool_file(<a href="#llvm_tool_file-tool">tool</a>)
 Return the label to an LLVM tool.
 
 Returns a label to the file, rather than an executable rule.
-This might is useful in repository rules that want to run an LLVM tool.
+This might be useful in repository rules that want to run an LLVM tool.
 
 
 **PARAMETERS**


### PR DESCRIPTION
## Summary

Fix 2 typos in documentation:

- **docs/features.md** line 5: "Generage" → "Generate"
- **docs/llvm_tool.md** line 43: "might is useful" → "might be useful"

No functional changes — documentation only.